### PR TITLE
Added support for more effects both in presets and UI

### DIFF
--- a/app/core/presets.py
+++ b/app/core/presets.py
@@ -8,29 +8,21 @@ import app.core.config as config
 class Preset:
     def __init__(self,
                 name,
-                pitch_value,
-                downsample_amount,
-                override_pitch,
-                volume_boost):
+                effects):
         self.name = name
-        self.pitch_value = pitch_value
-        self.downsample_amount = downsample_amount
-        self.override_pitch = override_pitch
-        self.volume_boost = volume_boost
+        self.effects = effects
 
     @staticmethod
     def from_dict(d):
         '''
         Constructs a `Preset` instance from a dictionary item and returns it
         '''
+        name = d.pop('name')
 
         # pylint: disable=bad-continuation
         return Preset(
-                name=d['name'],
-                pitch_value=d['pitch_value'],
-                downsample_amount=key_or_default(key='downsample_amount',  dict=d, default='1'),
-                override_pitch=key_or_default(key='override_pitch_slider', dict=d, default='false'),
-                volume_boost=key_or_default(key='volume_boost', dict=d, default='0')
+                name=name,
+                effects=d
         )
 
 def load_presets():
@@ -62,70 +54,49 @@ PRESETS_CONTENTS = '''
 
 [[presets]]
 name = "Man"
-pitch_value = "-1.5"
-downsample_amount = "none"
-override_pitch_slider = true
+pitch = [-150]
 
 [[presets]]
 name = "Woman"
-pitch_value = "2.5"
-downsample_amount = "none"
-override_pitch_slider = true
+pitch = [250]
 
 [[presets]]
 name = "Boy"
-pitch_value = "1.25"
-downsample_amount = "none"
-override_pitch_slider = true
+pitch = [125]
 
 [[presets]]
 name = "Girl"
-pitch_value = "2.8"
-downsample_amount = "none"
-override_pitch_slider = true
+pitch = [280]
 
 [[presets]]
 name = "Darth Vader"
-pitch_value = "-6"
-downsample_amount = "none"
-override_pitch_slider = true
+pitch = [-600]
 
 [[presets]]
 name = "Chipmunk"
-pitch_value = "10.0"
-downsample_amount = "none"
-override_pitch_slider = true
+pitch = [1000]
 
 [[presets]]
 name = "Russian Mic"
-pitch_value = "scale"
-downsample_amount = "8"
-override_pitch_slider = false
-volume_boost = "8"
+downsample = [8]
+vol = ["8dB"]
 
 [[presets]]
 name = "Radio"
-pitch_value = "scale"
-downsample_amount = "6"
-override_pitch_slider = false
-volume_boost = "5"
+downsample = [6]
+vol = ["5dB"]
 
 [[presets]]
 name = "Megaphone"
-pitch_value = "scale"
-downsample_amount = "2"
-override_pitch_slider = false
-volume_boost = "8"
+downsample = [2]
+vol = ["8dB"]
 
 [[presets]]
 name = "Custom"
-pitch_value = "scale"
-downsample_amount = "none"
-override_pitch_slider = false
 '''
 
 def create_presets():
     config.create_config_dir()
-    if not config.presets_path.exists():
+    if not config.presets_path.exists() or True:
         with open(config.presets_path, 'w') as f:
             f.write(PRESETS_CONTENTS)

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -18,15 +18,16 @@ def build_sox_command(preset, config_object=None, ui_values=None):
     '''
     Builds and returns a sox command from a preset object
     '''
-    multiplier = 100
     effects = []
 
     for effect_name, effect_params in preset.effects.items():
         params_str = ' '.join(map(str, effect_params))
         effects.append(f'{effect_name} {params_str}')
 
-    if 'pitch' not in preset.effects:
-        effects.append(f'pitch {ui_values["pitch"] * multiplier}')
+    # Apply scales effects after preset effects only if they are not already applied by preset
+    for effect_name, effect_value in ui_values.items():
+        if effect_name not in preset.effects:
+            effects.append(f'{effect_name} {effect_value}')
 
     sox_effects = ' '.join(effects)
     command = f'sox --buffer {config_object.buffer_size or 1024} -q -t pulseaudio default -t pulseaudio Lyrebird-Output {sox_effects}'

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -29,8 +29,14 @@ def build_sox_command(preset, config_object=None, ui_values=None):
         if effect_name not in preset.effects:
             effects.append(f'{effect_name} {effect_value}')
 
+    # To fix the error which appear when no effects applied
     sox_effects = ' '.join(effects)
+    if not sox_effects:
+        sox_effects = 'pitch 0'
+
     command = f'sox --buffer {config_object.buffer_size or 1024} -q -t pulseaudio default -t pulseaudio Lyrebird-Output {sox_effects}'
+
+    print(command)
 
     return command
 

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -14,35 +14,19 @@ from gi.repository import Gtk, Gdk, GdkPixbuf
 def key_or_default(key, dict, default):
     return dict[key] if key in dict else default
 
-def build_sox_command(preset, config_object=None, scale_object=None):
+def build_sox_command(preset, config_object=None, ui_values=None):
     '''
     Builds and returns a sox command from a preset object
     '''
     multiplier = 100
     effects = []
 
+    for effect_name, effect_params in preset.effects.items():
+        params_str = ' '.join(map(str, effect_params))
+        effects.append(f'{effect_name} {params_str}')
 
-    # Pitch shift
-    if preset.pitch_value == 'default':
-        effects.append('pitch 0')
-    if preset.pitch_value == 'scale':
-        effects.append(f'pitch {float(scale_object.get_value()) * multiplier}')
-    else:
-        effects.append(f'pitch {float(preset.pitch_value) * multiplier}')
-
-    # Volume boosting
-    if preset.volume_boost == 'default' or preset.volume_boost == None:
-        effects.append('vol 0dB')
-    else:
-        effects.append(f'vol {int(preset.volume_boost)}dB')
-
-    # Downsampling
-    if preset.downsample_amount != 'none':
-        effects.append(f'downsample {int(preset.downsample_amount)}')
-    else:
-        # Append downsample of 1 to fix a bug where the downsample isn't being reverted
-        # when we disable the effect with it on.
-        effects.append('downsample 1')
+    if 'pitch' not in preset.effects:
+        effects.append(f'pitch {ui_values["pitch"] * multiplier}')
 
     sox_effects = ' '.join(effects)
     command = f'sox --buffer {config_object.buffer_size or 1024} -q -t pulseaudio default -t pulseaudio Lyrebird-Output {sox_effects}'


### PR DESCRIPTION
Hello! Recently I discovered this beautiful program, and liked the simplicity of the interface very much, but it seemed odd to me that the only parameter user can change is pitch, so I decided to change this. Namely, the changes I made:
1. Replaced hardcoded parameters for specific effects by `effects` dictionary in Preset, which contains effects' names as keys and arrays with parameters as values.
2. Changed the code for default presets so it corresponds to this new principle - effect name as key, and array with parameters to this effect as value.
3. Wrote a function `build_parameter_row`, which handles all the code needed for adding new scales and make it require minimum code changes.
4. Updated other functions, such as `build_sox_command` or `scale_moved` respectively.
5. Moved some duplicated code to functions, such as `restart_sox` or `set_preset`.
6. Added scales for two new effects, lowpass and highpass, and switches for all the effects to turn them off if not needed.

Unfortunately, I don't know much about how to properly test it, but on my laptop it seems to work fine, so I hope it's the same with others :)

This is my first pull request, so please do not judge strictly if there's something wrong. Let me know about the issues and maybe I'll be able to fix them! Thanks in advance.