### PR TITLE
Smart unloading of Pulse sinks

### DIFF
--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -49,17 +49,6 @@ def build_sox_command(preset, config_object=None, scale_object=None):
 
     return command
 
-def unload_pa_modules(check_state=False):
-    '''
-    Unloads both the PulseAudio null output
-    If `check_state` is `True`, then this will check if `state.sink` is not -1.
-    '''
-
-    # Unload if we don't care about state, or we do and there is a sink loaded
-    if not check_state or state.sink != -1:
-        subprocess.call('pacmd unload-module module-null-sink'.split(" "))
-        subprocess.call('pacmd unload-module module-remap-source'.split(' '))
-
 def show_error_message(msg, parent, title):
     '''
     Create an error message dialog with string message.
@@ -100,3 +89,49 @@ def destroy_lock():
     '''
     if lock_file_path.exists():
         lock_file_path.unlink()
+        
+def parse_pactl_info_short(lines):
+    '''
+    Parses `pactl info short` into tuples containing the module ID,
+    the module type and the attributes of the module. It is designed
+    only for named modules and as such junk data may be included in
+    the returned list.
+    
+    Returns an array of tuples that take the form:
+        (module_id (str), module_type (str), attributes (attribute tuples))
+      
+    The attribute tuples:
+        (key (str), value (str))
+        
+    An example output might look like:
+        [
+            ( '30', 'module-null-sink', [('sink_name', 'Lyrebird-Output')] ),
+            ( '31', 'module-remap-source', [('source_name', 'Lyrebird-Input'), ('master', 'Lyrebird-Output.monitor')] )
+        ]
+    '''
+    data = []
+    split_lines = lines.split("\n")
+    for line in split_lines:
+        info = line.split("\t")
+        if len(info) <= 1:
+            continue
+        
+        if info[2] and len(info[2]) > 0:
+            key_values = list(map(lambda key_value: tuple(key_value.split("=")), info[2].split(" ")))
+            data.append((info[0], info[1], key_values))
+        else:
+            data.append((info[0], info[1], []))
+    return data
+    
+def unload_pa_modules():
+    '''
+    Unloads all Lyrebird null sinks.
+    '''
+    pactl_list = subprocess.run(["pactl", "list", "short"], capture_output=True, encoding="utf8")
+    stdout = pactl_list.stdout
+    modules = parse_pactl_info_short(stdout)
+    lyrebird_modules = []
+    for module in modules:
+        is_lyrebird = False
+
+        

--- a/app/mainwindow.py
+++ b/app/mainwindow.py
@@ -149,7 +149,7 @@ class MainWindow(Gtk.Window):
         about = Gtk.AboutDialog()
         about.set_program_name('Lyrebird Voice Changer')
         about.set_version("v1.1.0")
-        about.set_copyright('(c) Charlotte 2020')
+        about.set_copyright('(c) Lyrebird 2020-2022')
         about.set_comments('Simple and powerful voice changer for Linux, written in GTK 3')
         about.set_logo(GdkPixbuf.Pixbuf.new_from_file('icon.png'))
 
@@ -160,24 +160,14 @@ class MainWindow(Gtk.Window):
         if switch.get_active():
             # Load module-null-sink
             null_sink = subprocess.check_call(
-                'pacmd load-module module-null-sink sink_name=Lyrebird-Output'.split(' ')
+                'pactl load-module module-null-sink sink_name=Lyrebird-Output node.description="Lyrebird Output"'.split(' ')
             )
             remap_sink = subprocess.check_call(
-                'pacmd load-module module-remap-source source_name=Lyrebird-Input master=Lyrebird-Output.monitor'\
+                'pactl load-module module-remap-source source_name=Lyrebird-Input master=Lyrebird-Output.monitor node.description="Lyrebird Virtual Input"'\
                     .split(' ')
             )
 
-            print(f'Loaded null output sink ({null_sink}), and remap sink ({remap_sink})')
-
-            subprocess.check_call(
-                'pacmd update-sink-proplist Lyrebird-Output device.description="Lyrebird Output"'\
-                    .split(' ')
-            )
-            subprocess.check_call(
-                'pacmd update-source-proplist Lyrebird-Input device.description="Lyrebird Virtual Input"'\
-                    .split(' ')
-            )
-
+            print(f'Loaded null output sink and remap sink')
 
             state.sink = null_sink
 
@@ -206,7 +196,7 @@ class MainWindow(Gtk.Window):
                 )
             self.sox_process = subprocess.Popen(command.split(' '))
         else:
-            utils.unload_pa_modules(check_state=True)
+            utils.unload_pa_modules()
             self.terminate_sox()
 
     def pitch_scale_moved(self, event):
@@ -269,5 +259,5 @@ class MainWindow(Gtk.Window):
         self.terminate_sox()
         self.lock_file.close()
         utils.destroy_lock()
-        utils.unload_pa_modules(check_state=False)
+        utils.unload_pa_modules()
         Gtk.main_quit()

--- a/app/mainwindow.py
+++ b/app/mainwindow.py
@@ -59,7 +59,7 @@ class MainWindow(Gtk.Window):
         # Unload the null sink module if there is one from last time.
         # The only reason there would be one already, is if the application was closed without
         # toggling the switch to off (aka a crash was experienced).
-        utils.unload_pa_modules(check_state=False)
+        utils.unload_pa_modules()
 
         # Load the configuration file
         state.config = config.load_config()


### PR DESCRIPTION
* Instead of blindly unloading all Pulse sinks which was inconvenient at best and unstable at worst, Lyrebird now parses Pulse's sinks and unloads the ones that it created.
* `pacmd` to `pactl`.