### PR TITLE
Fix 2 bugs to get program working.

### DIFF
--- a/app/core/audio.py
+++ b/app/core/audio.py
@@ -30,7 +30,7 @@ class Audio:
             command_effects += ["vol", str(preset.volume_boost) + "dB"]
         else:
             # Fix a bug where SoX uses last given volumne
-            command_effects += ["vol", "0"]
+            command_effects += ["vol", "0dB"]
 
         # Downsampling
         if preset.downsample_amount != None:

--- a/app/core/audio.py
+++ b/app/core/audio.py
@@ -52,13 +52,8 @@ class Audio:
             return None
 
     def load_pa_modules(self):
-        self.null_sink = subprocess.check_call(
-            'pactl load-module module-null-sink sink_name=Lyrebird-Output node.description="Lyrebird Output"'.split(' ')
-        )
-        self.remap_sink = subprocess.check_call(
-            'pactl load-module module-remap-source source_name=Lyrebird-Input master=Lyrebird-Output.monitor node.description="Lyrebird Virtual Input"'\
-                .split(' ')
-        )
+        self.null_sink = subprocess.check_call(['pactl', 'load-module', 'module-null-sink', 'sink_name=Lyrebird-Output', 'sink_properties=device.description=Lyrebird_Output'])
+        self.remap_sink = subprocess.check_call(['pactl', 'load-module', 'module-remap-source', 'source_name=Lyrebird-Input', 'master=Lyrebird-Output.monitor', 'source_properties=device.description=Lyrebird_Virtual_Input'])
 
     def get_pactl_modules(self):
         '''


### PR DESCRIPTION
Fixes 2 bug. 1 with the pactl commands, other with the sox vol argument. The program seems to be working now, at least for me with pulseaudio, not pipewire-pulse. Note that I did also change the "node.description" argument you provided to pactl before to "sink_properties=device.description=" and "source_properties=device.description=". The node.description wasn't working for me. I tried to get the spaces in the descriptions to work by typing it like 'sink_properties=device.description="Lyrebird Output"' but that wouldn't work for me either, so I just changed it to underscores.